### PR TITLE
Docker server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,4 +11,6 @@ docs/.vitepress/cache
 config.toml
 nodeget-config*
 .env
+*.env
+!*.env.example
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.git
+ .git
 .github
 target
 node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,6 @@ docs/.vitepress/cache
 *.db-wal
 *.local.toml
 config.toml
-nodeget-config
+nodeget-config*
 .env
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+target
+node_modules
+docs/.vitepress/dist
+docs/.vitepress/cache
+*.db
+*.db-shm
+*.db-wal
+*.local.toml
+config.toml
+nodeget-config
+.env
+.DS_Store

--- a/.github/workflows/server-docker.yml
+++ b/.github/workflows/server-docker.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/nodeget-server
+  IMAGE_NAME: nodeseekdev/nodeget-server
   DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME || 'nodeseek/nodeget-server' }}
 
 jobs:

--- a/.github/workflows/server-docker.yml
+++ b/.github/workflows/server-docker.yml
@@ -1,6 +1,12 @@
 name: nodeget-server-docker
 
 on:
+  pull_request:
+    paths:
+      - "Dockerfile.server"
+      - "docker/server/**"
+      - "docker-compose.*.yml"
+      - ".github/workflows/server-docker.yml"
   workflow_dispatch:
     inputs:
       nodeget_version:
@@ -29,7 +35,34 @@ env:
   DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME || 'nodeseek/nodeget-server' }}
 
 jobs:
+  build-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.server
+          platforms: linux/amd64
+          push: false
+          build-args: |
+            NODEGET_VERSION=latest
+            NODEGET_RELEASE_REPO=GenshinMinecraft/NodeGet
+
   docker:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/server-docker.yml
+++ b/.github/workflows/server-docker.yml
@@ -7,6 +7,10 @@ on:
         description: NodeGet release tag to package
         required: false
         default: latest
+      nodeget_release_repo:
+        description: GitHub repository that hosts NodeGet release assets
+        required: false
+        default: GenshinMinecraft/NodeGet
   push:
     branches:
       - main
@@ -49,6 +53,16 @@ jobs:
             echo "value=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set release repository
+        id: release-repo
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.nodeget_release_repo }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=GenshinMinecraft/NodeGet" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -88,6 +102,7 @@ jobs:
           push: true
           build-args: |
             NODEGET_VERSION=${{ steps.version.outputs.value }}
+            NODEGET_RELEASE_REPO=${{ steps.release-repo.outputs.value }}
           tags: ${{ steps.meta-ghcr.outputs.tags }}
           labels: ${{ steps.meta-ghcr.outputs.labels }}
 
@@ -112,5 +127,6 @@ jobs:
           push: true
           build-args: |
             NODEGET_VERSION=${{ steps.version.outputs.value }}
+            NODEGET_RELEASE_REPO=${{ steps.release-repo.outputs.value }}
           tags: ${{ steps.meta-dockerhub.outputs.tags }}
           labels: ${{ steps.meta-dockerhub.outputs.labels }}

--- a/.github/workflows/server-docker.yml
+++ b/.github/workflows/server-docker.yml
@@ -1,0 +1,116 @@
+name: nodeget-server-docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      nodeget_version:
+        description: NodeGet release tag to package
+        required: false
+        default: latest
+  push:
+    branches:
+      - main
+      - dev
+    tags:
+      - "v*"
+    paths:
+      - "Dockerfile.server"
+      - "docker/server/**"
+      - "docker-compose.*.yml"
+      - ".github/workflows/server-docker.yml"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/nodeget-server
+  DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME || 'nodeseek/nodeget-server' }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set NodeGet version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.nodeget_version }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Extract GHCR metadata
+        id: meta-ghcr
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Build and push GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            NODEGET_VERSION=${{ steps.version.outputs.value }}
+          tags: ${{ steps.meta-ghcr.outputs.tags }}
+          labels: ${{ steps.meta-ghcr.outputs.labels }}
+
+      - name: Extract Docker Hub metadata
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        id: meta-dockerhub
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Build and push Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            NODEGET_VERSION=${{ steps.version.outputs.value }}
+          tags: ${{ steps.meta-dockerhub.outputs.tags }}
+          labels: ${{ steps.meta-dockerhub.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target/
 test.db*
 .idea/
 .env
+*.env
+!*.env.example
 .DS_Store
 *.iml
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test.db*
 Thumbs.db
 list_all_rs_file.py
 config.toml
+nodeget-config*/
 node_modules/
 docs/.vitepress/dist
 docs/.vitepress/cache

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,6 +2,7 @@ FROM alpine:3.20
 
 ARG NODEGET_VERSION=latest
 ARG NODEGET_RELEASE_REPO=GenshinMinecraft/NodeGet
+ARG NODEGET_SERVER_SHA256=
 ARG TARGETARCH
 
 ENV NODEGET_CONFIG=/config/config.toml \
@@ -10,7 +11,11 @@ ENV NODEGET_CONFIG=/config/config.toml \
     NODEGET_LOG_FILTER=info \
     NODEGET_DATABASE_URL=sqlite:///config/nodeget.db?mode=rwc
 
-RUN apk add --no-cache ca-certificates curl tar
+RUN apk add --no-cache ca-certificates curl su-exec tar \
+    && addgroup -S nodeget \
+    && adduser -S -G nodeget -h /config -s /sbin/nologin nodeget \
+    && mkdir -p /config \
+    && chown nodeget:nodeget /config
 
 COPY docker/server/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
@@ -28,6 +33,9 @@ RUN set -eux; \
         url="https://github.com/${NODEGET_RELEASE_REPO}/releases/download/${NODEGET_VERSION}/${asset}"; \
     fi; \
     curl -fsSL "$url" -o /usr/local/bin/nodeget-server; \
+    if [ -n "${NODEGET_SERVER_SHA256}" ]; then \
+        echo "${NODEGET_SERVER_SHA256}  /usr/local/bin/nodeget-server" | sha256sum -c -; \
+    fi; \
     chmod +x /usr/local/bin/nodeget-server
 
 EXPOSE 3000

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,7 @@
 FROM alpine:3.20
 
 ARG NODEGET_VERSION=latest
+ARG NODEGET_RELEASE_REPO=GenshinMinecraft/NodeGet
 ARG TARGETARCH
 
 ENV NODEGET_CONFIG=/config/config.toml \
@@ -22,9 +23,9 @@ RUN set -eux; \
     esac; \
     asset="nodeget-server-linux-${asset_arch}-musl"; \
     if [ "${NODEGET_VERSION}" = "latest" ]; then \
-        url="https://github.com/NodeSeekDev/NodeGet/releases/latest/download/${asset}"; \
+        url="https://github.com/${NODEGET_RELEASE_REPO}/releases/latest/download/${asset}"; \
     else \
-        url="https://github.com/NodeSeekDev/NodeGet/releases/download/${NODEGET_VERSION}/${asset}"; \
+        url="https://github.com/${NODEGET_RELEASE_REPO}/releases/download/${NODEGET_VERSION}/${asset}"; \
     fi; \
     curl -fsSL "$url" -o /usr/local/bin/nodeget-server; \
     chmod +x /usr/local/bin/nodeget-server

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -8,7 +8,7 @@ ENV NODEGET_CONFIG=/config/config.toml \
     NODEGET_PORT=3000 \
     NODEGET_SERVER_UUID=auto_gen \
     NODEGET_LOG_FILTER=info \
-    NODEGET_DATABASE_URL=sqlite:///tmp/nodeget.db?mode=rwc
+    NODEGET_DATABASE_URL=sqlite:///config/nodeget.db?mode=rwc
 
 RUN apk add --no-cache ca-certificates curl tar
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,35 @@
+FROM alpine:3.20
+
+ARG NODEGET_VERSION=latest
+ARG TARGETARCH
+
+ENV NODEGET_CONFIG=/etc/nodeget/config.toml \
+    NODEGET_PORT=3000 \
+    NODEGET_SERVER_UUID=auto_gen \
+    NODEGET_LOG_FILTER=info \
+    NODEGET_DATABASE_URL=sqlite:///tmp/nodeget.db?mode=rwc
+
+RUN apk add --no-cache ca-certificates curl tar
+
+COPY docker/server/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) asset_arch="x86_64" ;; \
+        arm64) asset_arch="aarch64" ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    asset="nodeget-server-linux-${asset_arch}-musl"; \
+    if [ "${NODEGET_VERSION}" = "latest" ]; then \
+        url="https://github.com/NodeSeekDev/NodeGet/releases/latest/download/${asset}"; \
+    else \
+        url="https://github.com/NodeSeekDev/NodeGet/releases/download/${NODEGET_VERSION}/${asset}"; \
+    fi; \
+    curl -fsSL "$url" -o /usr/local/bin/nodeget-server; \
+    chmod +x /usr/local/bin/nodeget-server
+
+EXPOSE 3000
+VOLUME ["/config"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["serve"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -3,7 +3,7 @@ FROM alpine:3.20
 ARG NODEGET_VERSION=latest
 ARG TARGETARCH
 
-ENV NODEGET_CONFIG=/etc/nodeget/config.toml \
+ENV NODEGET_CONFIG=/config/config.toml \
     NODEGET_PORT=3000 \
     NODEGET_SERVER_UUID=auto_gen \
     NODEGET_LOG_FILTER=info \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ NodeGet 是一款基于 ***Rust*** 语言编写的服务器管理、监控软件
 ## **相关链接**
 
 - **官方文档**：<https://nodeget.com>
+- **Server Docker 部署**：[docker/server/README.md](docker/server/README.md)
 - **设计 Intro**：<https://www.nodeseek.com/post-704497-1>
 - **Telegram 频道**：[@NodeGetProject](https://t.me/NodeGetProject)
 - **Telegram 讨论组**：[@NodegetGroup](https://t.me/NodegetGroup)

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -11,6 +11,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
   nodeget:
     image: ghcr.io/nodeseekdev/nodeget-server:latest
@@ -31,3 +33,6 @@ services:
       NODEGET_DATABASE_URL: postgres://nodeget:nodeget@postgres:5432/nodeget
     volumes:
       - ./nodeget-config-postgres:/config
+
+volumes:
+  postgres-data:

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -5,7 +5,7 @@ services:
     environment:
       POSTGRES_DB: nodeget
       POSTGRES_USER: nodeget
-      POSTGRES_PASSWORD: nodeget
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nodeget -d nodeget"]
       interval: 10s
@@ -30,7 +30,7 @@ services:
       NODEGET_PORT: 3000
       NODEGET_SERVER_UUID: auto_gen
       NODEGET_LOG_FILTER: info
-      NODEGET_DATABASE_URL: postgres://nodeget:nodeget@postgres:5432/nodeget
+      NODEGET_DATABASE_URL: postgres://nodeget:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/nodeget
     volumes:
       - ./nodeget-config-postgres:/config
 

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: nodeget
+      POSTGRES_USER: nodeget
+      POSTGRES_PASSWORD: nodeget
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nodeget -d nodeget"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  nodeget:
+    image: ghcr.io/nodeseekdev/nodeget-server:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      NODEGET_CONFIG: /config/config.toml
+      NODEGET_PORT: 3000
+      NODEGET_SERVER_UUID: auto_gen
+      NODEGET_LOG_FILTER: info
+      NODEGET_DATABASE_URL: postgres://nodeget:nodeget@postgres:5432/nodeget
+    volumes:
+      - ./nodeget-config:/config

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -30,4 +30,4 @@ services:
       NODEGET_LOG_FILTER: info
       NODEGET_DATABASE_URL: postgres://nodeget:nodeget@postgres:5432/nodeget
     volumes:
-      - ./nodeget-config:/config
+      - ./nodeget-config-postgres:/config

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -14,4 +14,4 @@ services:
       NODEGET_LOG_FILTER: info
       NODEGET_DATABASE_URL: sqlite:///tmp/nodeget.db?mode=rwc
     volumes:
-      - ./nodeget-config:/config
+      - ./nodeget-config-sqlite:/config

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -12,6 +12,6 @@ services:
       NODEGET_PORT: 3000
       NODEGET_SERVER_UUID: auto_gen
       NODEGET_LOG_FILTER: info
-      NODEGET_DATABASE_URL: sqlite:///tmp/nodeget.db?mode=rwc
+      NODEGET_DATABASE_URL: sqlite:///config/nodeget.db?mode=rwc
     volumes:
       - ./nodeget-config-sqlite:/config

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -1,0 +1,17 @@
+services:
+  nodeget:
+    image: ghcr.io/nodeseekdev/nodeget-server:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      NODEGET_CONFIG: /config/config.toml
+      NODEGET_PORT: 3000
+      NODEGET_SERVER_UUID: auto_gen
+      NODEGET_LOG_FILTER: info
+      NODEGET_DATABASE_URL: sqlite:///tmp/nodeget.db?mode=rwc
+    volumes:
+      - ./nodeget-config:/config

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -14,6 +14,8 @@ docker compose -f docker-compose.sqlite.yml up -d
 PostgreSQL:
 
 ```bash
+cp docker/server/postgres.env.example .env
+# Edit .env and set a strong POSTGRES_PASSWORD before starting.
 docker compose -f docker-compose.postgres.yml up -d
 ```
 
@@ -48,6 +50,8 @@ If you mount your own `config.toml`, the environment variables are not written i
 SQLite uses `./nodeget-config-sqlite/config.toml` and `./nodeget-config-sqlite/nodeget.db`.
 PostgreSQL uses `./nodeget-config-postgres/config.toml` and the `postgres-data` named volume.
 
+The entrypoint prepares `/config` when needed, then runs `nodeget-server` as the unprivileged `nodeget` user.
+
 ## Commands
 
 ```bash
@@ -72,6 +76,7 @@ Build arguments:
 
 - `NODEGET_VERSION`: release tag to package, default `latest`
 - `NODEGET_RELEASE_REPO`: repository that hosts release assets, default `GenshinMinecraft/NodeGet`
+- `NODEGET_SERVER_SHA256`: optional SHA-256 checksum for the downloaded server binary
 
 Supported platforms:
 
@@ -88,11 +93,13 @@ Docker Hub publishing is optional. Configure these repository secrets to enable 
 - `DOCKERHUB_TOKEN`
 
 Optionally set `DOCKERHUB_IMAGE_NAME` as a repository variable. The default is `nodeseek/nodeget-server`.
+GHCR publishing uses `ghcr.io/nodeseekdev/nodeget-server`.
 
 ## Verification
 
 ```bash
 docker compose -f docker-compose.sqlite.yml config
+cp docker/server/postgres.env.example .env
 docker compose -f docker-compose.postgres.yml config
 docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 --build-arg NODEGET_RELEASE_REPO=GenshinMinecraft/NodeGet -t nodeget-server:local .
 docker run --rm nodeget-server:local version

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -1,0 +1,38 @@
+# NodeGet Server Docker
+
+This image runs `nodeget-server` on Alpine Linux by downloading the released musl binary.
+
+## Configuration
+
+The container uses `/etc/nodeget/config.toml` by default. If the file does not exist, the entrypoint generates it from environment variables.
+
+Supported environment variables:
+
+- `NODEGET_PORT`: server port, default `3000`
+- `NODEGET_SERVER_UUID`: server UUID, default `auto_gen`
+- `NODEGET_LOG_FILTER`: log filter, default `info`
+- `NODEGET_DATABASE_URL`: database URL, default `sqlite:///etc/nodeget/nodeget.db?mode=rwc`
+- `NODEGET_DATABASE_MAX_CONNECTIONS`: database max connections, default `10`
+- `NODEGET_CONFIG`: config path, default `/etc/nodeget/config.toml`
+
+If you mount your own `config.toml`, the environment variables are not written into it.
+The compose files persist `./nodeget-config/config.toml` only. Other runtime data is not persisted by default.
+The SQLite compose file stores its database in `/tmp`, so it is suitable for simple or disposable deployments.
+
+## SQLite
+
+```bash
+docker compose -f docker-compose.sqlite.yml up -d
+```
+
+## PostgreSQL
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+```
+
+## Build
+
+```bash
+docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 -t nodeget-server:local .
+```

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -28,14 +28,25 @@ Supported environment variables:
 - `NODEGET_PORT`: server port, default `3000`
 - `NODEGET_SERVER_UUID`: server UUID, default `auto_gen`
 - `NODEGET_LOG_FILTER`: log filter, default `info`
-- `NODEGET_DATABASE_URL`: database URL, default `sqlite:///tmp/nodeget.db?mode=rwc`
+- `NODEGET_DATABASE_URL`: database URL, default `sqlite:///config/nodeget.db?mode=rwc`
 - `NODEGET_DATABASE_MAX_CONNECTIONS`: database max connections, default `10`
 - `NODEGET_CONFIG`: config path, default `/config/config.toml`
 
+Additional environment variables map to the defaults in `server/config.toml.example`:
+
+- `NODEGET_JSONRPC_MAX_CONNECTIONS`
+- `NODEGET_ENABLE_UNIX_SOCKET`
+- `NODEGET_UNIX_SOCKET_PATH`
+- `NODEGET_MONITORING_FLUSH_INTERVAL_MS`
+- `NODEGET_MONITORING_MAX_BATCH_SIZE`
+- `NODEGET_DATABASE_CONNECT_TIMEOUT_MS`
+- `NODEGET_DATABASE_ACQUIRE_TIMEOUT_MS`
+- `NODEGET_DATABASE_IDLE_TIMEOUT_MS`
+- `NODEGET_DATABASE_MAX_LIFETIME_MS`
+
 If you mount your own `config.toml`, the environment variables are not written into it.
-The compose files persist their generated `config.toml` only. Other runtime data is not persisted by default.
-SQLite uses `./nodeget-config-sqlite/config.toml`; PostgreSQL uses `./nodeget-config-postgres/config.toml`.
-The SQLite compose file stores its database in `/tmp`, so it is suitable for simple or disposable deployments.
+SQLite uses `./nodeget-config-sqlite/config.toml` and `./nodeget-config-sqlite/nodeget.db`.
+PostgreSQL uses `./nodeget-config-postgres/config.toml` and the `postgres-data` named volume.
 
 ## Commands
 

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -2,37 +2,84 @@
 
 This image runs `nodeget-server` on Alpine Linux by downloading the released musl binary.
 
+## Quick Start
+
+SQLite:
+
+```bash
+docker compose -f docker-compose.sqlite.yml up -d
+```
+
+PostgreSQL:
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+```
+
+The server listens on port `3000` by default.
+
 ## Configuration
 
-The container uses `/etc/nodeget/config.toml` by default. If the file does not exist, the entrypoint generates it from environment variables.
+The container uses `/config/config.toml` by default. If the file does not exist, the entrypoint generates it from environment variables.
 
 Supported environment variables:
 
 - `NODEGET_PORT`: server port, default `3000`
 - `NODEGET_SERVER_UUID`: server UUID, default `auto_gen`
 - `NODEGET_LOG_FILTER`: log filter, default `info`
-- `NODEGET_DATABASE_URL`: database URL, default `sqlite:///etc/nodeget/nodeget.db?mode=rwc`
+- `NODEGET_DATABASE_URL`: database URL, default `sqlite:///tmp/nodeget.db?mode=rwc`
 - `NODEGET_DATABASE_MAX_CONNECTIONS`: database max connections, default `10`
-- `NODEGET_CONFIG`: config path, default `/etc/nodeget/config.toml`
+- `NODEGET_CONFIG`: config path, default `/config/config.toml`
 
 If you mount your own `config.toml`, the environment variables are not written into it.
 The compose files persist `./nodeget-config/config.toml` only. Other runtime data is not persisted by default.
 The SQLite compose file stores its database in `/tmp`, so it is suitable for simple or disposable deployments.
 
-## SQLite
+## Commands
 
 ```bash
-docker compose -f docker-compose.sqlite.yml up -d
+docker run --rm ghcr.io/nodeseekdev/nodeget-server:latest version
+docker run --rm -v ./nodeget-config:/config ghcr.io/nodeseekdev/nodeget-server:latest get-uuid
 ```
 
-## PostgreSQL
+The entrypoint automatically appends `--config /config/config.toml` for these commands:
 
-```bash
-docker compose -f docker-compose.postgres.yml up -d
-```
+- `serve`
+- `init`
+- `roll-super-token`
+- `get-uuid`
 
-## Build
+## Build Locally
 
 ```bash
 docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 -t nodeget-server:local .
+```
+
+Build arguments:
+
+- `NODEGET_VERSION`: release tag to package, default `latest`
+
+Supported platforms:
+
+- `linux/amd64`
+- `linux/arm64`
+
+## CI Publishing
+
+The `nodeget-server-docker` workflow builds and pushes the image to GHCR.
+
+Docker Hub publishing is optional. Configure these repository secrets to enable it:
+
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+
+Optionally set `DOCKERHUB_IMAGE_NAME` as a repository variable. The default is `nodeseek/nodeget-server`.
+
+## Verification
+
+```bash
+docker compose -f docker-compose.sqlite.yml config
+docker compose -f docker-compose.postgres.yml config
+docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 -t nodeget-server:local .
+docker run --rm nodeget-server:local version
 ```

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -1,6 +1,7 @@
 # NodeGet Server Docker
 
 This image runs `nodeget-server` on Alpine Linux by downloading the released musl binary.
+Release assets are currently downloaded from `GenshinMinecraft/NodeGet` by default because the official repository release workflow is temporarily unavailable.
 
 ## Quick Start
 
@@ -32,14 +33,15 @@ Supported environment variables:
 - `NODEGET_CONFIG`: config path, default `/config/config.toml`
 
 If you mount your own `config.toml`, the environment variables are not written into it.
-The compose files persist `./nodeget-config/config.toml` only. Other runtime data is not persisted by default.
+The compose files persist their generated `config.toml` only. Other runtime data is not persisted by default.
+SQLite uses `./nodeget-config-sqlite/config.toml`; PostgreSQL uses `./nodeget-config-postgres/config.toml`.
 The SQLite compose file stores its database in `/tmp`, so it is suitable for simple or disposable deployments.
 
 ## Commands
 
 ```bash
 docker run --rm ghcr.io/nodeseekdev/nodeget-server:latest version
-docker run --rm -v ./nodeget-config:/config ghcr.io/nodeseekdev/nodeget-server:latest get-uuid
+docker run --rm -v ./nodeget-config-sqlite:/config ghcr.io/nodeseekdev/nodeget-server:latest get-uuid
 ```
 
 The entrypoint automatically appends `--config /config/config.toml` for these commands:
@@ -58,6 +60,7 @@ docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 -t nodeget-
 Build arguments:
 
 - `NODEGET_VERSION`: release tag to package, default `latest`
+- `NODEGET_RELEASE_REPO`: repository that hosts release assets, default `GenshinMinecraft/NodeGet`
 
 Supported platforms:
 
@@ -80,6 +83,6 @@ Optionally set `DOCKERHUB_IMAGE_NAME` as a repository variable. The default is `
 ```bash
 docker compose -f docker-compose.sqlite.yml config
 docker compose -f docker-compose.postgres.yml config
-docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 -t nodeget-server:local .
+docker build -f Dockerfile.server --build-arg NODEGET_VERSION=v0.0.6 --build-arg NODEGET_RELEASE_REPO=GenshinMinecraft/NodeGet -t nodeget-server:local .
 docker run --rm nodeget-server:local version
 ```

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -9,22 +9,24 @@ mkdir -p "$config_dir"
 if [ ! -f "$config_path" ]; then
     cat > "$config_path" <<EOF
 ws_listener = "0.0.0.0:${NODEGET_PORT:-3000}"
-jsonrpc_max_connections = 100
-enable_unix_socket = false
-unix_socket_path = "/var/lib/nodeget.sock"
+jsonrpc_max_connections = ${NODEGET_JSONRPC_MAX_CONNECTIONS:-100}
+enable_unix_socket = ${NODEGET_ENABLE_UNIX_SOCKET:-false}
+unix_socket_path = "${NODEGET_UNIX_SOCKET_PATH:-/var/lib/nodeget.sock}"
 server_uuid = "${NODEGET_SERVER_UUID:-auto_gen}"
 
 [logging]
 log_filter = "${NODEGET_LOG_FILTER:-info}"
 
 [monitoring_buffer]
+flush_interval_ms = ${NODEGET_MONITORING_FLUSH_INTERVAL_MS:-500}
+max_batch_size = ${NODEGET_MONITORING_MAX_BATCH_SIZE:-1000}
 
 [database]
-database_url = "${NODEGET_DATABASE_URL:-sqlite:///tmp/nodeget.db?mode=rwc}"
-connect_timeout_ms = 3000
-acquire_timeout_ms = 3000
-idle_timeout_ms = 3000
-max_lifetime_ms = 30000
+database_url = "${NODEGET_DATABASE_URL:-sqlite:///config/nodeget.db?mode=rwc}"
+connect_timeout_ms = ${NODEGET_DATABASE_CONNECT_TIMEOUT_MS:-3000}
+acquire_timeout_ms = ${NODEGET_DATABASE_ACQUIRE_TIMEOUT_MS:-3000}
+idle_timeout_ms = ${NODEGET_DATABASE_IDLE_TIMEOUT_MS:-3000}
+max_lifetime_ms = ${NODEGET_DATABASE_MAX_LIFETIME_MS:-30000}
 max_connections = ${NODEGET_DATABASE_MAX_CONNECTIONS:-10}
 EOF
 fi

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+config_path="${NODEGET_CONFIG:-/etc/nodeget/config.toml}"
+config_dir="$(dirname "$config_path")"
+
+mkdir -p "$config_dir"
+
+if [ ! -f "$config_path" ]; then
+    cat > "$config_path" <<EOF
+ws_listener = "0.0.0.0:${NODEGET_PORT:-3000}"
+jsonrpc_max_connections = 100
+enable_unix_socket = false
+unix_socket_path = "/var/lib/nodeget.sock"
+server_uuid = "${NODEGET_SERVER_UUID:-auto_gen}"
+
+[logging]
+log_filter = "${NODEGET_LOG_FILTER:-info}"
+
+[monitoring_buffer]
+
+[database]
+database_url = "${NODEGET_DATABASE_URL:-sqlite:///tmp/nodeget.db?mode=rwc}"
+connect_timeout_ms = 3000
+acquire_timeout_ms = 3000
+idle_timeout_ms = 3000
+max_lifetime_ms = 30000
+max_connections = ${NODEGET_DATABASE_MAX_CONNECTIONS:-10}
+EOF
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- serve
+fi
+
+case "$1" in
+    serve|init|roll-super-token|get-uuid)
+        command="$1"
+        shift
+        set -- nodeget-server "$command" --config "$config_path" "$@"
+        ;;
+    version|--version|-V)
+        set -- nodeget-server version
+        ;;
+    nodeget-server)
+        ;;
+    *)
+        set -- nodeget-server "$@"
+        ;;
+esac
+
+exec "$@"

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-config_path="${NODEGET_CONFIG:-/etc/nodeget/config.toml}"
+config_path="${NODEGET_CONFIG:-/config/config.toml}"
 config_dir="$(dirname "$config_path")"
 
 mkdir -p "$config_dir"
@@ -31,6 +31,10 @@ max_connections = ${NODEGET_DATABASE_MAX_CONNECTIONS:-10}
 EOF
 fi
 
+if [ "$(id -u)" -eq 0 ]; then
+    chown -R nodeget:nodeget "$config_dir"
+fi
+
 if [ "$#" -eq 0 ]; then
     set -- serve
 fi
@@ -50,5 +54,9 @@ case "$1" in
         set -- nodeget-server "$@"
         ;;
 esac
+
+if [ "$(id -u)" -eq 0 ] && [ "$1" = "nodeget-server" ]; then
+    set -- su-exec nodeget "$@"
+fi
 
 exec "$@"

--- a/docker/server/postgres.env.example
+++ b/docker/server/postgres.env.example
@@ -1,0 +1,1 @@
+POSTGRES_PASSWORD=change-this-password


### PR DESCRIPTION
## 概要

  为 `nodeget-server` 增加 Docker 化支持。

  本 PR 包含：

  - 基于 Alpine 的 `nodeget-server` 镜像
  - 容器启动时可根据环境变量生成配置文件
  - 支持挂载已有 `config.toml`
  - SQLite 版 Docker Compose 示例
  - PostgreSQL + NodeGet 版 Docker Compose 示例
  - GHCR 镜像发布 workflow
  - 配置 Docker Hub secrets 后可选发布到 Docker Hub
  - PR 场景下的 Docker build 检查，只构建不推送

  ## 说明

  Docker 镜像不会在镜像内从源码编译 NodeGet，而是直接下载已发布的 musl binary。

  目前 release 产物默认从 `GenshinMinecraft/NodeGet` 下载，因为官方仓库的 release workflow 暂时不可用。该地址通过 `NODEGET_RELEASE_REPO` build arg 配置，后续官方 workflow 恢复后，可以直接切回 `NodeSeekDev/NodeGet`。

  ## 配置方式

  容器默认使用：

  ```text
  /config/config.toml
  ```

  如果该文件不存在，entrypoint 会根据环境变量自动生成配置。

  支持的环境变量：

  - NODEGET_PORT
  - NODEGET_SERVER_UUID
  - NODEGET_LOG_FILTER
  - NODEGET_DATABASE_URL
  - NODEGET_DATABASE_MAX_CONNECTIONS
  - NODEGET_CONFIG

  如果用户挂载了自己的 config.toml，容器会直接使用该文件，不会覆盖。

  ## Docker Compose

  提供两份 compose 文件：

  - docker-compose.sqlite.yml
  - docker-compose.postgres.yml

  Compose 示例默认只持久化生成的配置文件：

  - SQLite: ./nodeget-config-sqlite/config.toml
  - PostgreSQL: ./nodeget-config-postgres/config.toml

  其他运行时数据默认不持久化。