### PR TITLE
Feat: Add Docker support with multi-stage build and CI/CD

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,93 @@
+name: Publish Docker Image
+
+on:
+  workflow_run:
+    workflows: ["nodeget-server-build"]
+    types:
+      - completed
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (latest, dev, or vX.Y.Z)'
+        required: true
+        default: 'latest'
+
+env:
+  REGISTRY_GHCR: ghcr.io
+  IMAGE_NAME: nodeseekdev/nodeget-server
+
+jobs:
+  build-and-push:
+    # 只在 server-build 工作流成功时执行
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry (GHCR)
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        # 仅当配置了 Docker Hub 的 Secret 时才尝试登录
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+            # 只有配置了 Docker Hub Secret 才会推送到 Docker Hub
+            ${{ secrets.DOCKERHUB_USERNAME != '' && format('{0}/nodeget-server', secrets.DOCKERHUB_USERNAME) || '' }}
+          tags: |
+            # 如果是 dev 分支触发，则标签为 dev
+            type=raw,value=dev,enable=${{ github.event.workflow_run.head_branch == 'dev' }}
+            # 如果是 main 分支触发，则标签为 latest
+            type=raw,value=latest,enable=${{ github.event.workflow_run.head_branch == 'main' }}
+            # 如果是手动触发，则使用输入的版本
+            type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Determine Download Version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event.workflow_run.head_branch }}" == "dev" ]]; then
+            echo "VERSION=dev" >> $GITHUB_ENV
+          else
+            echo "VERSION=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Stage 1: Download the pre-compiled musl binary
+FROM alpine:latest AS downloader
+
+ARG TARGETARCH
+ARG VERSION=latest
+
+RUN apk add --no-cache wget ca-certificates tzdata
+
+WORKDIR /app
+
+RUN set -ex; \
+    if [ -z "$TARGETARCH" ]; then \
+        ARCH=$(uname -m); \
+        if [ "$ARCH" = "x86_64" ]; then TARGETARCH="amd64"; \
+        elif [ "$ARCH" = "aarch64" ]; then TARGETARCH="arm64"; \
+        else echo "Unsupported architecture: $ARCH"; exit 1; fi; \
+    fi; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        ARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        ARCH="aarch64"; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; \
+        exit 1; \
+    fi; \
+    BINARY_NAME="nodeget-server-linux-${ARCH}-musl"; \
+    if [ "$VERSION" = "latest" ]; then \
+        DOWNLOAD_URL="https://github.com/NodeSeekDev/NodeGet/releases/latest/download/${BINARY_NAME}"; \
+    elif [ "$VERSION" = "dev" ]; then \
+        DOWNLOAD_URL="https://github.com/NodeSeekDev/NodeGet/releases/download/dev/${BINARY_NAME}"; \
+    else \
+        DOWNLOAD_URL="https://github.com/NodeSeekDev/NodeGet/releases/download/${VERSION}/${BINARY_NAME}"; \
+    fi; \
+    echo "Downloading ${DOWNLOAD_URL}..."; \
+    wget -qO /app/nodeget-server "$DOWNLOAD_URL"; \
+    chmod +x /app/nodeget-server
+
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Stage 2: Runtime with minimal alpine
+FROM alpine:3.21 AS runtime
+
+WORKDIR /app
+
+# Copy only what's needed for runtime
+COPY --from=downloader /app/nodeget-server /app/nodeget-server
+COPY --from=downloader /app/entrypoint.sh /app/entrypoint.sh
+COPY --from=downloader /etc/ssl/certs /etc/ssl/certs
+COPY --from=downloader /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Default Environment Variables
+ENV PORT=3000
+ENV SERVER_UUID=auto_gen
+ENV LOG_FILTER=info
+ENV DATABASE_URL=sqlite://nodeget.db?mode=rwc
+
+EXPOSE 3000
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/compose.pgsql.yml
+++ b/compose.pgsql.yml
@@ -1,0 +1,34 @@
+services:
+  nodeget-server:
+    image: ghcr.io/nodeseekdev/nodeget-server:latest
+    container_name: nodeget-server
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+      - SERVER_UUID=auto_gen
+      - LOG_FILTER=info
+      - DATABASE_URL=postgres://nodeget:nodeget_password@postgres:5432/nodeget
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:15-alpine
+    container_name: nodeget-postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=nodeget
+      - POSTGRES_PASSWORD=nodeget_password
+      - POSTGRES_DB=nodeget
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nodeget -d nodeget"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/compose.sqlite.yml
+++ b/compose.sqlite.yml
@@ -1,0 +1,15 @@
+services:
+  nodeget-server:
+    image: ghcr.io/nodeseekdev/nodeget-server:latest
+    container_name: nodeget-server
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+      - SERVER_UUID=auto_gen
+      - LOG_FILTER=info
+      - DATABASE_URL=sqlite://nodeget.db?mode=rwc
+    volumes:
+      # SQLite 数据库文件持久化
+      - ./nodeget.db:/app/nodeget.db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+CONFIG_FILE="/app/config.toml"
+
+# If config.toml does not exist, generate it from environment variables
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Generating config.toml from environment variables..."
+    cat <<EOF > "$CONFIG_FILE"
+ws_listener = "0.0.0.0:${PORT:-3000}"
+server_uuid = "${SERVER_UUID:-auto_gen}"
+
+[logging]
+log_filter = "${LOG_FILTER:-info}"
+
+[database]
+database_url = "${DATABASE_URL:-sqlite://nodeget.db?mode=rwc}"
+EOF
+else
+    echo "Found existing config.toml, using it."
+fi
+
+# 默认执行 serve 命令
+if [ $# -eq 0 ]; then
+    set -- serve
+fi
+
+# 如果第一个参数是内置的子命令，则自动注入 nodeget-server 和 -c 参数
+case "$1" in
+    serve|init|roll-super-token|get-uuid)
+        CMD="$1"
+        shift
+        exec /app/nodeget-server "$CMD" -c "$CONFIG_FILE" "$@"
+        ;;
+    *)
+        # 否则作为普通命令执行（如 /bin/sh）
+        exec "$@"
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile using alpine:3.21 for minimal runtime (~3-4MB)
- Download pre-compiled musl binary from GitHub releases (no build required)
- Add entrypoint.sh to generate config.toml from environment variables
- Add compose.pgsql.yml for PostgreSQL deployment
- Add compose.sqlite.yml for SQLite deployment
- Add docker-publish.yml workflow for GHCR and Docker Hub publishing

## Changes
| File | Description |
|------|-------------|
| `Dockerfile` | Multi-stage build, runtime uses alpine:3.21 |
| `entrypoint.sh` | Auto-generate config.toml from ENV |
| `compose.pgsql.yml` | PostgreSQL + NodeGet deployment |
| `compose.sqlite.yml` | SQLite deployment |
| `.github/workflows/docker-publish.yml` | CI/CD for GHCR + Docker Hub |

## Usage
```bash
# PostgreSQL
docker compose -f compose.pgsql.yml up -d

# SQLite
docker compose -f compose.sqlite.yml up -d
```

All configuration via environment variables, no config file mapping required.

## Test plan
- [ ] Verify Dockerfile builds successfully for amd64 and arm64
- [ ] Test PostgreSQL compose deployment
- [ ] Test SQLite compose deployment
- [ ] Verify CI/CD workflow triggers on server-build completion