### PR TITLE
添加 Docker 镜像支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.github
+target
+**/target
+node_modules
+docs/.vitepress/cache
+*.db
+*.sqlite
+*.sqlite3
+Dockerfile
+docker-compose*.yml
+README.md
+CONTRIBUTING.md

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: nodeseekdev/nodeget-server
+  IMAGE_NAME: llleixx/nodeget-server
   RUST_IMAGE: rustlang/rust:nightly-alpine3.22
 
 jobs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,64 @@
+name: nodeget-server-docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nodeseekdev/nodeget-server
+  RUST_IMAGE: rustlang/rust:nightly-alpine3.22
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime-source
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            RUST_IMAGE=${{ env.RUST_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1
+
+ARG ALPINE_VERSION=3.22
+ARG RUST_IMAGE=rustlang/rust:nightly-alpine3.22
+
+FROM alpine:${ALPINE_VERSION} AS release-binary
+
+ARG NODEGET_VERSION=latest
+ARG NODEGET_RELEASE_REPO=NodeSeekDev/NodeGet
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN apk add --no-cache ca-certificates curl
+
+RUN set -eux; \
+    docker_target="${TARGETARCH}${TARGETVARIANT}"; \
+    if [ -z "${docker_target}" ]; then \
+        docker_target="$(apk --print-arch)"; \
+    fi; \
+    case "${docker_target}" in \
+        amd64* | x86_64) asset="nodeget-server-linux-x86_64-musl" ;; \
+        arm64* | aarch64) asset="nodeget-server-linux-aarch64-musl" ;; \
+        armv7) asset="nodeget-server-linux-armv7-musleabihf" ;; \
+        *) \
+            echo "Unsupported Docker target: ${docker_target}. Supported: linux/amd64, linux/arm64, linux/arm/v7" >&2; \
+            exit 1; \
+            ;; \
+    esac; \
+    if [ "${NODEGET_VERSION}" = "latest" ]; then \
+        release_path="latest/download"; \
+    else \
+        release_path="download/${NODEGET_VERSION}"; \
+    fi; \
+    mkdir -p /out; \
+    curl -fsSL --retry 5 --retry-delay 2 \
+        "https://github.com/${NODEGET_RELEASE_REPO}/releases/${release_path}/${asset}" \
+        -o /out/nodeget-server; \
+    chmod 0755 /out/nodeget-server
+
+FROM ${RUST_IMAGE} AS source-binary
+
+WORKDIR /src
+
+RUN apk add --no-cache build-base clang clang-dev git musl-dev pkgconf
+
+COPY . .
+
+RUN cargo build --package nodeget-server --profile minimal --locked \
+    && mkdir -p /out \
+    && cp target/minimal/nodeget-server /out/nodeget-server \
+    && chmod 0755 /out/nodeget-server
+
+FROM alpine:${ALPINE_VERSION} AS runtime-base
+
+LABEL org.opencontainers.image.title="NodeGet Server"
+LABEL org.opencontainers.image.description="NodeGet server runtime image based on Alpine Linux"
+LABEL org.opencontainers.image.source="https://github.com/NodeSeekDev/NodeGet"
+LABEL org.opencontainers.image.licenses="AGPL-3.0"
+
+RUN apk add --no-cache ca-certificates tzdata \
+    && update-ca-certificates \
+    && mkdir -p /etc/nodeget /var/lib/nodeget
+
+COPY docker/entrypoint.sh /usr/local/bin/nodeget-entrypoint
+
+RUN chmod 0755 /usr/local/bin/nodeget-entrypoint
+
+WORKDIR /var/lib/nodeget
+
+ENV NODEGET_CONFIG="/etc/nodeget/config.toml" \
+    NODEGET_PORT="3000" \
+    NODEGET_SERVER_UUID="auto_gen" \
+    NODEGET_LOG_FILTER="info" \
+    NODEGET_DATABASE_URL="sqlite:///var/lib/nodeget/nodeget.db?mode=rwc"
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/nodeget-entrypoint"]
+CMD ["serve"]
+
+FROM runtime-base AS runtime-release
+COPY --from=release-binary /out/nodeget-server /usr/local/bin/nodeget-server
+
+FROM runtime-base AS runtime-source
+COPY --from=source-binary /out/nodeget-server /usr/local/bin/nodeget-server
+
+FROM runtime-release AS runtime

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,38 @@
+name: nodeget-postgres
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB:-nodeget}"
+      POSTGRES_USER: "${POSTGRES_USER:-nodeget}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-nodeget}"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  nodeget:
+    image: "${NODEGET_IMAGE:-ghcr.io/nodeseekdev/nodeget-server:latest}"
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODEGET_CONFIG_FROM_ENV: "true"
+      NODEGET_PORT: "${NODEGET_PORT:-3000}"
+      NODEGET_SERVER_UUID: "${NODEGET_SERVER_UUID:-auto_gen}"
+      NODEGET_LOG_FILTER: "${NODEGET_LOG_FILTER:-info}"
+      NODEGET_DATABASE_URL: "${NODEGET_DATABASE_URL:-postgres://${POSTGRES_USER:-nodeget}:${POSTGRES_PASSWORD:-nodeget}@postgres:5432/${POSTGRES_DB:-nodeget}}"
+    ports:
+      - "${NODEGET_HOST_PORT:-3000}:${NODEGET_PORT:-3000}"
+    volumes:
+      - ./data/config.toml:/etc/nodeget/config.toml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- \"http://127.0.0.1:$${NODEGET_PORT:-3000}/\" >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -1,0 +1,22 @@
+name: nodeget-sqlite
+
+services:
+  nodeget:
+    image: "${NODEGET_IMAGE:-ghcr.io/nodeseekdev/nodeget-server:latest}"
+    restart: unless-stopped
+    environment:
+      NODEGET_CONFIG_FROM_ENV: "true"
+      NODEGET_PORT: "${NODEGET_PORT:-3000}"
+      NODEGET_SERVER_UUID: "${NODEGET_SERVER_UUID:-auto_gen}"
+      NODEGET_LOG_FILTER: "${NODEGET_LOG_FILTER:-info}"
+      NODEGET_DATABASE_URL: "${NODEGET_DATABASE_URL:-sqlite:///var/lib/nodeget/nodeget.db?mode=rwc}"
+    ports:
+      - "${NODEGET_HOST_PORT:-3000}:${NODEGET_PORT:-3000}"
+    volumes:
+      - ./data/config.toml:/etc/nodeget/config.toml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- \"http://127.0.0.1:$${NODEGET_PORT:-3000}/\" >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+CONFIG_PATH="${NODEGET_CONFIG:-/etc/nodeget/config.toml}"
+DATA_DIR="${NODEGET_DATA_DIR:-/var/lib/nodeget}"
+
+as_bool() {
+    case "${1:-}" in
+        1 | true | TRUE | yes | YES | on | ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+toml_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+write_config_from_env() {
+    port="${NODEGET_PORT:-${PORT:-3000}}"
+    ws_listener="${NODEGET_WS_LISTENER:-0.0.0.0:${port}}"
+    server_uuid="${NODEGET_SERVER_UUID:-${SERVER_UUID:-auto_gen}}"
+    log_filter="${NODEGET_LOG_FILTER:-${LOG_FILTER:-info}}"
+    database_url="${NODEGET_DATABASE_URL:-${DATABASE_URL:-sqlite:///${DATA_DIR}/nodeget.db?mode=rwc}}"
+
+    cat >"${CONFIG_PATH}" <<EOF
+ws_listener = "$(toml_escape "${ws_listener}")"
+jsonrpc_max_connections = ${NODEGET_JSONRPC_MAX_CONNECTIONS:-100}
+enable_unix_socket = ${NODEGET_ENABLE_UNIX_SOCKET:-false}
+unix_socket_path = "$(toml_escape "${NODEGET_UNIX_SOCKET_PATH:-/var/lib/nodeget.sock}")"
+server_uuid = "$(toml_escape "${server_uuid}")"
+
+[logging]
+log_filter = "$(toml_escape "${log_filter}")"
+
+[monitoring_buffer]
+flush_interval_ms = ${NODEGET_MONITORING_FLUSH_INTERVAL_MS:-500}
+max_batch_size = ${NODEGET_MONITORING_MAX_BATCH_SIZE:-1000}
+
+[database]
+database_url = "$(toml_escape "${database_url}")"
+connect_timeout_ms = ${NODEGET_DB_CONNECT_TIMEOUT_MS:-3000}
+acquire_timeout_ms = ${NODEGET_DB_ACQUIRE_TIMEOUT_MS:-3000}
+idle_timeout_ms = ${NODEGET_DB_IDLE_TIMEOUT_MS:-3000}
+max_lifetime_ms = ${NODEGET_DB_MAX_LIFETIME_MS:-30000}
+max_connections = ${NODEGET_DB_MAX_CONNECTIONS:-10}
+EOF
+}
+
+has_config_arg() {
+    for arg in "$@"; do
+        case "${arg}" in
+            -c | --config | --config=*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+mkdir -p "$(dirname "${CONFIG_PATH}")" "${DATA_DIR}"
+
+if [ ! -f "${CONFIG_PATH}" ] || as_bool "${NODEGET_CONFIG_FROM_ENV:-false}"; then
+    write_config_from_env
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- serve
+fi
+
+case "$1" in
+    nodeget-server)
+        if [ "$#" -ge 2 ]; then
+            subcommand="$2"
+            case "${subcommand}" in
+                serve | init | get-uuid | roll-super-token)
+                    shift 2
+                    if has_config_arg "$@"; then
+                        set -- nodeget-server "${subcommand}" "$@"
+                    else
+                        set -- nodeget-server "${subcommand}" "$@" -c "${CONFIG_PATH}"
+                    fi
+                    ;;
+            esac
+        fi
+        ;;
+    serve | init | get-uuid | roll-super-token)
+        subcommand="$1"
+        shift
+        if has_config_arg "$@"; then
+            set -- nodeget-server "${subcommand}" "$@"
+        else
+            set -- nodeget-server "${subcommand}" "$@" -c "${CONFIG_PATH}"
+        fi
+        ;;
+    version | -h | --help)
+        set -- nodeget-server "$@"
+        ;;
+esac
+
+exec "$@"

--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -2,7 +2,48 @@
 
 ## 安装 Server
 
-待支持
+官方 Docker 镜像由 CI 从源码编译并推送到 GHCR：
+
+- `ghcr.io/nodeseekdev/nodeget-server:latest`：最新发布版本镜像
+- `ghcr.io/nodeseekdev/nodeget-server:vX.Y.Z`：Release tag 镜像
+
+### PostgreSQL + NodeGet
+
+```shell
+mkdir -p nodeget
+touch nodeget/config.toml
+curl -fsSL https://raw.githubusercontent.com/NodeSeekDev/NodeGet/main/docker-compose.postgres.yml -o docker-compose.yml
+docker compose up -d
+```
+
+### SQLite
+
+```shell
+mkdir -p nodeget
+touch nodeget/config.toml
+curl -fsSL https://raw.githubusercontent.com/NodeSeekDev/NodeGet/main/docker-compose.sqlite.yml -o docker-compose.yml
+docker compose up -d
+```
+
+默认暴露 `3000` 端口。可通过环境变量覆盖常用配置：
+
+```shell
+NODEGET_HOST_PORT=2211 \
+NODEGET_PORT=2211 \
+NODEGET_SERVER_UUID=auto_gen \
+NODEGET_LOG_FILTER=info \
+docker compose up -d
+```
+
+PostgreSQL 部署时如需修改数据库密码，设置 `POSTGRES_PASSWORD` 即可；默认的 `NODEGET_DATABASE_URL` 会自动使用同一组 `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD`。
+
+如需使用指定镜像 tag：
+
+```shell
+NODEGET_IMAGE=ghcr.io/nodeseekdev/nodeget-server:v0.0.6 docker compose up -d
+```
+
+Compose 示例只持久化 `./nodeget/config.toml`。若希望完全手动维护配置文件，可以取消 `NODEGET_CONFIG_FROM_ENV=true`，直接编辑 `./nodeget/config.toml`。
 
 ## 安装 Agent
 


### PR DESCRIPTION
## 概要

本 PR 为 NodeGet Server 增加 Docker 部署支持。

## 主要改动

- 新增基于 Alpine runtime 的 `Dockerfile`
- 新增 `docker/entrypoint.sh`，用于生成或复用 `config.toml`
- 新增 GHCR 镜像构建与推送 Workflow
- 新增 SQLite / PostgreSQL 两份 Docker Compose 部署文件
- 更新 Docker 安装文档

## Docker 镜像发布策略

Docker 镜像只在推送 `v*` 格式的版本 tag 时由 GitHub Actions 构建并推送。

推送的镜像 tag：

- `ghcr.io/nodeseekdev/nodeget-server:latest`
- `ghcr.io/nodeseekdev/nodeget-server:vX.Y.Z`

`latest` 仅代表最新发布版本，不跟随 `main` 或 `dev` 分支。

## 部署方式

用户可直接从官方仓库 main 分支下载 Compose 文件：

SQLite：

```bash
mkdir -p nodeget
touch nodeget/config.toml
curl -fsSL https://raw.githubusercontent.com/NodeSeekDev/NodeGet/main/docker-compose.sqlite.yml -o docker-compose.yml
docker compose up -d

PostgreSQL：

mkdir -p nodeget
touch nodeget/config.toml
curl -fsSL https://raw.githubusercontent.com/NodeSeekDev/NodeGet/main/docker-compose.postgres.yml -o docker-compose.yml
docker compose up -d

## 持久化

当前仅持久化配置文件：

./nodeget/config.toml:/etc/nodeget/config.toml

按当前需求，SQLite 数据库文件不做额外持久化。

## 环境变量配置

容器支持通过环境变量生成配置：

- NODEGET_PORT
- NODEGET_SERVER_UUID
- NODEGET_LOG_FILTER
- NODEGET_DATABASE_URL
- NODEGET_IMAGE

当 NODEGET_CONFIG_FROM_ENV=true 时，entrypoint 会把这些值写入 config.toml。

## 维护者需要配置的内容

首次发布 GHCR 镜像前，需要确认：

- GitHub Actions workflow 权限允许写入：
    - Settings -> Actions -> General -> Workflow permissions -> Read and write permissions
- GITHUB_TOKEN 允许写入 GitHub Packages
- 首次推送 GHCR package 后，将 ghcr.io/nodeseekdev/nodeget-server 设置为 Public

## 已验证

本地已验证：

- shellcheck docker/entrypoint.sh
- docker compose -f docker-compose.sqlite.yml config
- docker compose -f docker-compose.postgres.yml config
- Workflow / Compose YAML 解析
- Docker 源码构建 target：
    - docker build --target runtime-source ...

CICD 已验证：

- https://github.com/llleixx/NodeGet/actions/runs/25200055861/job/73888948104

## 手动上传镜像攻略

1. 切到发布 tag 对应代码

git fetch --tags
git checkout v0.0.6

或者如果还没打 tag：

git checkout dev
git pull
git tag v0.0.6

2. 登录 GHCR

echo '<YOUR_GITHUB_PAT>' | docker login ghcr.io -u <你的GitHub用户名> --password-stdin

3. 准备 buildx

docker buildx create --name nodeget-builder --use 2>/dev/null || docker buildx use nodeget-builder
docker buildx inspect --bootstrap

4. 构建并推送多架构镜像

只推 latest 和 vX.Y.Z：

VERSION=v0.0.6

docker buildx build \
  --target runtime-source \
  --platform linux/amd64,linux/arm64 \
  -t ghcr.io/nodeseekdev/nodeget-server:${VERSION} \
  -t ghcr.io/nodeseekdev/nodeget-server:latest \
  --push \
  .

这会在本机编译源码，并直接推送 manifest list 到 GHCR。

5. 验证镜像

docker buildx imagetools inspect ghcr.io/nodeseekdev/nodeget-server:v0.0.6
docker buildx imagetools inspect ghcr.io/nodeseekdev/nodeget-server:latest

本机跑一下：

docker run --rm ghcr.io/nodeseekdev/nodeget-server:v0.0.6 version