### PR TITLE
Fix: Refine Docker deployment config and persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,7 @@ RUN chmod 0755 /usr/local/bin/nodeget-entrypoint
 
 WORKDIR /var/lib/nodeget
 
-ENV NODEGET_CONFIG="/etc/nodeget/config.toml" \
-    NODEGET_PORT="3000" \
+ENV NODEGET_PORT="3000" \
     NODEGET_SERVER_UUID="auto_gen" \
     NODEGET_LOG_FILTER="info" \
     NODEGET_DATABASE_URL="sqlite:///var/lib/nodeget/nodeget.db?mode=rwc"

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -5,34 +5,29 @@ services:
     image: postgres:17-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_DB: "${POSTGRES_DB:-nodeget}"
-      POSTGRES_USER: "${POSTGRES_USER:-nodeget}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-nodeget}"
+      POSTGRES_DB: nodeget
+      POSTGRES_USER: nodeget
+      POSTGRES_PASSWORD: nodeget
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      test: ["CMD-SHELL", "pg_isready -U nodeget -d nodeget"]
       interval: 5s
       timeout: 5s
       retries: 20
 
   nodeget:
-    image: "${NODEGET_IMAGE:-genshinmc/nodeget:latest}"
+    image: genshinmc/nodeget:latest
     restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      NODEGET_CONFIG_FROM_ENV: "true"
-      NODEGET_PORT: "${NODEGET_PORT:-3000}"
-      NODEGET_SERVER_UUID: "${NODEGET_SERVER_UUID:-auto_gen}"
-      NODEGET_LOG_FILTER: "${NODEGET_LOG_FILTER:-info}"
-      NODEGET_DATABASE_URL: "${NODEGET_DATABASE_URL:-postgres://${POSTGRES_USER:-nodeget}:${POSTGRES_PASSWORD:-nodeget}@postgres:5432/${POSTGRES_DB:-nodeget}}"
+      NODEGET_PORT: "3000"
+      NODEGET_SERVER_UUID: auto_gen
+      NODEGET_LOG_FILTER: info
+      NODEGET_DATABASE_URL: postgres://nodeget:nodeget@postgres:5432/nodeget
     ports:
-      - "${NODEGET_HOST_PORT:-3000}:${NODEGET_PORT:-3000}"
+      - "3000:3000"
     volumes:
-      - ./data/config.toml:/etc/nodeget/config.toml
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- \"http://127.0.0.1:$${NODEGET_PORT:-3000}/\" >/dev/null"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+      - ./data/config:/etc/nodeget

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -2,21 +2,15 @@ name: nodeget-sqlite
 
 services:
   nodeget:
-    image: "${NODEGET_IMAGE:-genshinmc/nodeget:latest}"
+    image: genshinmc/nodeget:latest
     restart: unless-stopped
     environment:
-      NODEGET_CONFIG_FROM_ENV: "true"
-      NODEGET_PORT: "${NODEGET_PORT:-3000}"
-      NODEGET_SERVER_UUID: "${NODEGET_SERVER_UUID:-auto_gen}"
-      NODEGET_LOG_FILTER: "${NODEGET_LOG_FILTER:-info}"
-      NODEGET_DATABASE_URL: "${NODEGET_DATABASE_URL:-sqlite:///var/lib/nodeget/nodeget.db?mode=rwc}"
+      NODEGET_PORT: "3000"
+      NODEGET_SERVER_UUID: auto_gen
+      NODEGET_LOG_FILTER: info
+      NODEGET_DATABASE_URL: sqlite:///var/lib/nodeget/nodeget.db?mode=rwc
     ports:
-      - "${NODEGET_HOST_PORT:-3000}:${NODEGET_PORT:-3000}"
+      - "3000:3000"
     volumes:
-      - ./data/config.toml:/etc/nodeget/config.toml
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- \"http://127.0.0.1:$${NODEGET_PORT:-3000}/\" >/dev/null"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+      - ./data/config:/etc/nodeget
+      - ./data/sqlite:/var/lib/nodeget

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,15 +1,8 @@
 #!/bin/sh
 set -eu
 
-CONFIG_PATH="${NODEGET_CONFIG:-/etc/nodeget/config.toml}"
+CONFIG_PATH="/etc/nodeget/config.toml"
 DATA_DIR="${NODEGET_DATA_DIR:-/var/lib/nodeget}"
-
-as_bool() {
-    case "${1:-}" in
-        1 | true | TRUE | yes | YES | on | ON) return 0 ;;
-        *) return 1 ;;
-    esac
-}
 
 toml_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
@@ -57,7 +50,12 @@ has_config_arg() {
 
 mkdir -p "$(dirname "${CONFIG_PATH}")" "${DATA_DIR}"
 
-if [ ! -f "${CONFIG_PATH}" ] || as_bool "${NODEGET_CONFIG_FROM_ENV:-false}"; then
+if [ -d "${CONFIG_PATH}" ]; then
+    echo "Config path ${CONFIG_PATH} is a directory. Remove it or replace it with a regular file." >&2
+    exit 1
+fi
+
+if [ ! -s "${CONFIG_PATH}" ]; then
     write_config_from_env
 fi
 

--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -10,8 +10,6 @@
 ### PostgreSQL + NodeGet
 
 ```shell
-mkdir -p nodeget
-touch nodeget/config.toml
 curl -fsSL https://raw.githubusercontent.com/NodeSeekDev/NodeGet/main/docker-compose.postgres.yml -o docker-compose.yml
 docker compose up -d
 ```
@@ -19,31 +17,28 @@ docker compose up -d
 ### SQLite
 
 ```shell
-mkdir -p nodeget
-touch nodeget/config.toml
 curl -fsSL https://raw.githubusercontent.com/NodeSeekDev/NodeGet/main/docker-compose.sqlite.yml -o docker-compose.yml
 docker compose up -d
 ```
 
-默认暴露 `3000` 端口。可通过环境变量覆盖常用配置：
+数据会保存在当前目录的 `./data` 下：
 
-```shell
-NODEGET_HOST_PORT=2211 \
-NODEGET_PORT=2211 \
-NODEGET_SERVER_UUID=auto_gen \
-NODEGET_LOG_FILTER=info \
-docker compose up -d
+```text
+data/
+  config/
+    config.toml
+  sqlite/
+    nodeget.db
+  postgres/
 ```
 
-PostgreSQL 部署时如需修改数据库密码，设置 `POSTGRES_PASSWORD` 即可；默认的 `NODEGET_DATABASE_URL` 会自动使用同一组 `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD`。
+`./data/config/config.toml` 是 NodeGet 配置文件。SQLite 部署使用 `./data/sqlite`，PostgreSQL 部署使用 `./data/postgres`。删除容器不会删除这些目录；如需清空数据，请停止服务后手动删除对应目录。
 
-如需使用指定镜像 tag：
+默认暴露 `3000` 端口。
 
-```shell
-NODEGET_IMAGE=genshinmc/nodeget:v0.0.6 docker compose up -d
-```
+如需修改镜像 tag、端口映射、数据库账号等 Docker 部署参数，请编辑下载下来的 `docker-compose.yml`。
 
-Compose 示例只持久化 `./nodeget/config.toml`。若希望完全手动维护配置文件，可以取消 `NODEGET_CONFIG_FROM_ENV=true`，直接编辑 `./nodeget/config.toml`。
+`./data/config/config.toml` 生成后，NodeGet 的运行配置以这个文件为准。修改监听地址、日志级别、数据库地址等 NodeGet 配置时，请编辑 `./data/config/config.toml`；只改 `docker-compose.yml` 不会覆盖已有配置文件。
 
 ## 安装 Agent
 


### PR DESCRIPTION
增加了 PostgreSQL 以及 SQLite 的持久化，补充了文档说明。

本地测试了一下：两个 compose 文件，通过本地编译镜像的形式，进行 compose up 没问题，调用了 server API 也没问题。