### PR TITLE
Fix: Update Docker configuration paths for NodeGet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,12 @@ COPY docker/entrypoint.sh /usr/local/bin/nodeget-entrypoint
 
 RUN chmod 0755 /usr/local/bin/nodeget-entrypoint
 
-WORKDIR /var/lib/nodeget
+WORKDIR /etc/nodeget
 
 ENV NODEGET_PORT="3000" \
     NODEGET_SERVER_UUID="auto_gen" \
     NODEGET_LOG_FILTER="info" \
+    NODEGET_CONFIG_PATH="/etc/nodeget/config.toml" \
     NODEGET_DATABASE_URL="sqlite:///var/lib/nodeget/nodeget.db?mode=rwc"
 
 EXPOSE 3000

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-CONFIG_PATH="/etc/nodeget/config.toml"
+CONFIG_PATH="${NODEGET_CONFIG_PATH:-/etc/nodeget/config.toml}"
 DATA_DIR="${NODEGET_DATA_DIR:-/var/lib/nodeget}"
 
 toml_escape() {


### PR DESCRIPTION
原来的配置文件目录不在工作目录之下，会出错：

<img width="2083" height="56" alt="8fe4f1014266619df49edd387058414b" src="https://github.com/user-attachments/assets/2bb38f6f-56b7-4ee3-84b0-435bad34aa6d" />
