### PR TITLE
Fix #67: Run JS host RPC calls on server runtime

### DIFF
--- a/server/src/js_runtime/inline_call.rs
+++ b/server/src/js_runtime/inline_call.rs
@@ -1,4 +1,5 @@
 use crate::js_runtime::js_error;
+use crate::js_runtime::server_runtime::spawn_on_server_runtime;
 use crate::rpc::js_worker::service::run_inline_call_and_record_result;
 use rquickjs::Error;
 use serde_json::Value;
@@ -21,15 +22,17 @@ pub async fn js_inline_call(
         )
     })?;
 
-    let result_value =
-        run_inline_call_and_record_result(js_worker_name, params, timeout_sec, inline_caller)
-            .await
-            .map_err(|e| js_error("inline_call", e.to_string()))?;
-
-    serde_json::to_string(&result_value).map_err(|e| {
-        js_error(
-            "inline_call",
-            format!("Failed to serialize inline_call result: {e}"),
-        )
+    let result_json = spawn_on_server_runtime(async move {
+        let result_value =
+            run_inline_call_and_record_result(js_worker_name, params, timeout_sec, inline_caller)
+                .await
+                .map_err(|e| e.to_string())?;
+        serde_json::to_string(&result_value)
+            .map_err(|e| format!("Failed to serialize inline_call result: {e}"))
     })
+    .await
+    .map_err(|e| js_error("inline_call", e))?
+    .map_err(|e| js_error("inline_call", e))?;
+
+    Ok(result_json)
 }

--- a/server/src/js_runtime/mod.rs
+++ b/server/src/js_runtime/mod.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 pub mod inline_call;
 pub mod nodeget;
 pub mod runtime_pool;
+pub(crate) mod server_runtime;
 
 pub(crate) const JS_RT_MEMORY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 

--- a/server/src/js_runtime/nodeget.rs
+++ b/server/src/js_runtime/nodeget.rs
@@ -1,4 +1,5 @@
 use crate::js_runtime::js_error;
+use crate::js_runtime::server_runtime::spawn_on_server_runtime;
 use crate::rpc::get_modules;
 use futures_util::future::join_all;
 use rquickjs::Error;
@@ -9,15 +10,19 @@ use tracing::{debug, trace};
 async fn raw_single_request(json: &str) -> StdResult<String, Error> {
     trace!(target: "js_runtime", "processing raw JSON-RPC request from JS");
     let rpc_module = get_modules();
+    let json = json.to_owned();
 
-    let (resp, _stream) = match rpc_module.raw_json_request(json, 16).await {
-        Ok(resp) => resp,
-        Err(e) => {
-            return Err(js_error("jsonrpc_module", e.to_string()));
-        }
-    };
+    let response = spawn_on_server_runtime(async move {
+        let (resp, _stream) = rpc_module
+            .raw_json_request(&json, 16)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok::<_, String>(resp.to_string())
+    })
+    .await
+    .map_err(|e| js_error("jsonrpc_module", e))?;
 
-    Ok(resp.to_string())
+    response.map_err(|e| js_error("jsonrpc_module", e))
 }
 
 /// # Errors

--- a/server/src/js_runtime/server_runtime.rs
+++ b/server/src/js_runtime/server_runtime.rs
@@ -1,0 +1,42 @@
+use std::future::Future;
+use std::sync::OnceLock;
+
+static SERVER_RUNTIME_HANDLE: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+
+pub fn init(handle: tokio::runtime::Handle) {
+    let _ = SERVER_RUNTIME_HANDLE.set(handle);
+}
+
+pub async fn spawn_on_server_runtime<F, T>(future: F) -> Result<T, String>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    // JS workers run inside dedicated short-lived/current-thread Tokio runtimes.
+    // Host calls that may touch server services or DB pools must execute on the
+    // long-lived server runtime so runtime-bound IO resources are not recycled
+    // into the wrong executor.
+    let handle = SERVER_RUNTIME_HANDLE
+        .get()
+        .ok_or_else(|| "server runtime handle is not initialized".to_owned())?;
+
+    let mut task = AbortOnDrop {
+        handle: handle.spawn(future),
+    };
+
+    (&mut task.handle)
+        .await
+        .map_err(|e| format!("server runtime task failed: {e}"))
+}
+
+struct AbortOnDrop<T> {
+    handle: tokio::task::JoinHandle<T>,
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if !self.handle.is_finished() {
+            self.handle.abort();
+        }
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -50,6 +50,7 @@ pub(crate) static RELOAD_NOTIFY: std::sync::OnceLock<tokio::sync::Notify> =
 #[tokio::main]
 async fn main() {
     println!("Starting nodeget-server");
+    js_runtime::server_runtime::init(tokio::runtime::Handle::current());
 
     let args = ServerArgs::par();
 


### PR DESCRIPTION
Fix #67: 

修复服务首次初始化期间，由 JS host call 触发 RPC/数据库访问时可能导致 PostgreSQL 连接池异常的问题。

JS worker 运行在独立的、短生命周期/current-thread Tokio runtime 中，但 `nodeget()` 和 `inlineCall()` 这类 host API 会进入 RPC 逻辑，并可能访问共享的服务状态和数据库连接池。此前这些数据库相关任务可能运行在 JS worker runtime 上，导致连接被绑定到错误的 runtime，进而出现类似错误：

- `A Tokio 1.x context was found, but it is being shutdown`
- `Failed to acquire connection from pool: Connection pool timed out`

本 PR 将这类 JS host call 显式桥接回长期存活的 server Tokio runtime 执行。

## 修改内容

- 启动时保存 server runtime handle。
- 新增 `spawn_on_server_runtime`，用于让 JS host call 中的服务/RPC/DB 任务回到 server runtime 执行。
- 将 `nodeget()` 的 raw JSON-RPC 请求切换到 server runtime 执行。
- 将 `inlineCall()` 的执行和结果序列化切换到 server runtime 执行。
- 当 JS 侧 await 被取消时，中止对应桥接任务，避免后台任务泄漏。

  ## 测试

- `cargo +nightly check -p nodeget-server`
- 已从源码成功构建 Docker runtime 镜像并进行测试

PostgreSQL 不再有原 Issue 提及的错误：

<img width="2065" height="1307" alt="f9c7445c7d94f4070839911b7fa4eefd" src="https://github.com/user-attachments/assets/2ba29565-7c6b-448e-a46a-329297fb6f0d" />

不影响 SQLite：

<img width="2086" height="1426" alt="741f7138990318430dcb68f688ae756d" src="https://github.com/user-attachments/assets/82890aa1-9f5d-4b4e-b38b-dd071b90ddef" />
