### PR TITLE
Fix: Docker server UUID generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,6 @@ RUN chmod 0755 /usr/local/bin/nodeget-entrypoint
 WORKDIR /etc/nodeget
 
 ENV NODEGET_PORT="2211" \
-    NODEGET_SERVER_UUID="auto_gen" \
     NODEGET_LOG_FILTER="info" \
     NODEGET_CONFIG_PATH="/etc/nodeget/config.toml" \
     NODEGET_DATABASE_URL="sqlite:///var/lib/nodeget/nodeget.db?mode=rwc"

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -24,7 +24,6 @@ services:
         condition: service_healthy
     environment:
       NODEGET_PORT: "2211"
-      NODEGET_SERVER_UUID: auto_gen
       NODEGET_LOG_FILTER: info
       NODEGET_DATABASE_URL: postgres://nodeget:nodeget@postgres:5432/nodeget
     ports:

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -6,7 +6,6 @@ services:
     restart: unless-stopped
     environment:
       NODEGET_PORT: "2211"
-      NODEGET_SERVER_UUID: auto_gen
       NODEGET_LOG_FILTER: info
       NODEGET_DATABASE_URL: sqlite:///var/lib/nodeget/nodeget.db?mode=rwc
     ports:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,10 +8,34 @@ toml_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
+generate_server_uuid() {
+    if [ -r /proc/sys/kernel/random/uuid ]; then
+        read -r uuid </proc/sys/kernel/random/uuid
+        printf '%s' "${uuid}"
+        return 0
+    fi
+
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen
+        return 0
+    fi
+
+    echo "Unable to generate server UUID: /proc/sys/kernel/random/uuid and uuidgen are unavailable." >&2
+    exit 1
+}
+
+resolve_server_uuid() {
+    if [ -n "${NODEGET_SERVER_UUID:-}" ]; then
+        printf '%s' "${NODEGET_SERVER_UUID}"
+    else
+        generate_server_uuid
+    fi
+}
+
 write_config_from_env() {
     port="${NODEGET_PORT:-${PORT:-2211}}"
     ws_listener="${NODEGET_WS_LISTENER:-0.0.0.0:${port}}"
-    server_uuid="${NODEGET_SERVER_UUID:-${SERVER_UUID:-auto_gen}}"
+    server_uuid="$(resolve_server_uuid)"
     log_filter="${NODEGET_LOG_FILTER:-${LOG_FILTER:-info}}"
     database_url="${NODEGET_DATABASE_URL:-${DATABASE_URL:-sqlite:///${DATA_DIR}/nodeget.db?mode=rwc}}"
 


### PR DESCRIPTION
<img width="2072" height="3792" alt="image" src="https://github.com/user-attachments/assets/1b1b1419-4eba-438f-a88f-4638965093e4" />


目前不会再出现 UUID 错误了，日志除了几个预期的 ERROR 就没其他问题了。

---

目前逻辑为：

- 如果 compose.yml 文件中有指定 NODEGET_SERVER_UUID，就直接传到生成的配置中去（无论是 `auto_gen` 还是真的 UUID）；
- 没有指定，则 entrypoint.sh 随机生成一个。