### PR TITLE
Fix agent config defaults and runtime behavior alignment

### DIFF
--- a/agent/config.toml.example
+++ b/agent/config.toml.example
@@ -32,8 +32,8 @@ exec_max_character = 10000
 # IP 地址获取服务提供商，可选 ipinfo / cloudflare，默认 ipinfo
 ip_provider = "ipinfo"
 
-# NTP 服务器地址，默认使用阿里云公共 NTP（time.pool.aliyun.com）
-ntp_server = "time.pool.aliyun.com"
+# NTP 服务器地址，默认使用 pool.ntp.org
+ntp_server = "pool.ntp.org"
 
 # 服务器列表
 # 可指定多个，以连接多个 Servers

--- a/agent/config.toml.example
+++ b/agent/config.toml.example
@@ -29,8 +29,8 @@ terminal_shell = "bash"
 # 超出该数量只返回命令的最后结果，上文将被截断，默认 10000
 exec_max_character = 10000
 
-# IP 地址获取服务提供商，可选 ipinfo / cloudflare，默认 ipinfo
-ip_provider = "ipinfo"
+# IP 地址获取服务提供商，可选 ipinfo / cloudflare，默认 cloudflare
+ip_provider = "cloudflare"
 
 # NTP 服务器地址，默认使用 pool.ntp.org
 ntp_server = "pool.ntp.org"

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> anyhow::Result<()> {
 
         // 仅在首次启动时查询 NTP 时间偏移，避免热重载时覆盖已有偏移导致时间跳变
         if NTP_INIT_DONE.get().is_none() {
-            let ntp_server = config.ntp_server.as_deref().unwrap_or("pool.ntp.org");
+            let ntp_server = config.ntp_server_or_default();
             let ntp_offset = ntp::fetch_ntp_offset(ntp_server).await;
             println!("NTP time offset: {ntp_offset} ms");
             set_ntp_offset_ms(ntp_offset);
@@ -121,7 +121,8 @@ async fn main() -> anyhow::Result<()> {
             NodegetError::ConfigNotFound("No server configuration found".to_owned())
         })?;
 
-        let mut handles = rpc::multi_server::init_connections(servers).await;
+        let connect_timeout = config.connect_timeout_duration();
+        let mut handles = rpc::multi_server::init_connections(servers, connect_timeout).await;
 
         handles.push(tokio::spawn(async {
             handle_static_monitoring_data_report().await;

--- a/agent/src/rpc/monitoring_data_report.rs
+++ b/agent/src/rpc/monitoring_data_report.rs
@@ -22,7 +22,7 @@ pub async fn handle_static_monitoring_data_report() {
         .expect("AGENT_CONFIG lock poisoned")
         .clone();
 
-    let interval_ms = agent_config.static_report_interval_ms.unwrap_or(300_000);
+    let interval_ms = agent_config.static_report_interval_ms_or_default();
     let mut ticker = interval(Duration::from_millis(interval_ms));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -70,10 +70,8 @@ pub async fn handle_dynamic_monitoring_data_report() {
         .expect("AGENT_CONFIG lock poisoned")
         .clone();
 
-    let dynamic_interval_ms = agent_config.dynamic_report_interval_ms.unwrap_or(1000);
-    let summary_interval_ms = agent_config
-        .dynamic_summary_report_interval_ms
-        .unwrap_or(1000);
+    let dynamic_interval_ms = agent_config.dynamic_report_interval_ms_or_default();
+    let summary_interval_ms = agent_config.dynamic_summary_report_interval_ms_or_default();
 
     // dynamic_interval_ms 是 summary_interval_ms 的整数倍（已在配置解析时校验）
     let ticks_per_dynamic = dynamic_interval_ms / summary_interval_ms;

--- a/agent/src/rpc/multi_server.rs
+++ b/agent/src/rpc/multi_server.rs
@@ -37,7 +37,10 @@ static CONNECTION_POOL: OnceCell<RwLock<HashMap<String, Arc<ServerHandle>>>> =
 //
 // # 参数
 // * `servers` - 服务器配置向量
-pub async fn init_connections(servers: Vec<Server>) -> Vec<JoinHandle<()>> {
+pub async fn init_connections(
+    servers: Vec<Server>,
+    connect_timeout: Duration,
+) -> Vec<JoinHandle<()>> {
     let mut map = HashMap::new();
     let mut handles = Vec::new();
 
@@ -57,6 +60,7 @@ pub async fn init_connections(servers: Vec<Server>) -> Vec<JoinHandle<()>> {
             server,
             uplink_rx,
             downlink_tx,
+            connect_timeout,
         )));
     }
 
@@ -86,6 +90,7 @@ async fn connection_manager(
     server: Server,
     mut uplink_rx: broadcast::Receiver<Message>,
     downlink_tx: broadcast::Sender<Message>,
+    connect_timeout: Duration,
 ) {
     // 临时定义用于检测 JsonRpc 长连接错误
     #[derive(Deserialize)]
@@ -108,7 +113,7 @@ async fn connection_manager(
     loop {
         info!("[{name}] Connecting to {url}...");
 
-        let ws_stream = match connect_with_retry(name, url).await {
+        let ws_stream = match connect_with_retry(name, url, connect_timeout).await {
             Ok(ws) => ws,
             Err(e) => {
                 error!("[{name}] Failed to connect: {e}");
@@ -330,22 +335,27 @@ async fn connection_manager(
 // # 参数
 // * `name` - 服务器名称（用于日志）
 // * `url` - WebSocket URL
+// * `connect_timeout` - 每次 WebSocket 建连尝试的超时时间
 //
 // # 返回值
 // 成功时返回 WebSocket 流，失败时返回错误
 async fn connect_with_retry(
     name: &str,
     url: &str,
+    connect_timeout: Duration,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
     let mut retry_count = 0;
     loop {
-        match timeout(Duration::from_secs(5), connect_async(url)).await {
+        match timeout(connect_timeout, connect_async(url)).await {
             Ok(Ok((ws_stream, _))) => return Ok(ws_stream),
             Ok(Err(e)) => {
                 warn!("[{name}] Connect failed: {e}");
             }
             Err(_) => {
-                warn!("[{name}] Connect timeout");
+                warn!(
+                    "[{name}] Connect timeout after {} ms",
+                    connect_timeout.as_millis()
+                );
             }
         }
 

--- a/agent/src/tasks/execute.rs
+++ b/agent/src/tasks/execute.rs
@@ -33,7 +33,7 @@ fn get_agent_config() -> Result<crate::AgentConfig> {
 // 成功时返回命令输出字符串，失败时返回错误信息
 pub async fn execute_command(task: ExecuteTask) -> Result<String> {
     let config = get_agent_config()?;
-    let max_chars = config.exec_max_character.unwrap_or(10000);
+    let max_chars = config.exec_max_character_or_default();
 
     if task.cmd.trim().is_empty() {
         return Err(NodegetError::InvalidInput(

--- a/agent/src/tasks/ip.rs
+++ b/agent/src/tasks/ip.rs
@@ -33,9 +33,9 @@ pub async fn ip() -> IPInfo {
         .and_then(|lock| {
             lock.read()
                 .ok()
-                .and_then(|config| config.ip_provider.clone())
+                .map(|config| config.ip_provider_or_default())
         })
-        .unwrap_or(IpProvider::Cloudflare);
+        .unwrap_or_default();
 
     match provider {
         IpProvider::Cloudflare => ip_cloudflare().await,

--- a/agent/src/tasks/pty.rs
+++ b/agent/src/tasks/pty.rs
@@ -5,8 +5,8 @@ use nodeget_lib::error::NodegetError;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::fs;
 use std::io::{Read, Write};
+use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::{
     sync::{RwLock, mpsc},
@@ -77,21 +77,60 @@ pub async fn handle_pty_url(
 
         let ws_stream = ws.0;
 
-        let cmd = if cfg!(windows) {
-            "cmd.exe"
-        } else if fs::exists("/bin/bash").unwrap_or(false) {
-            "bash"
-        } else {
-            "sh"
-        };
+        let cmd = terminal_shell()?;
 
-        handle_pty_session(ws_stream, cmd).await
+        handle_pty_session(ws_stream, &cmd).await
     }
     .await;
 
     release_terminal_id(&terminal_id).await;
 
     connect_result
+}
+
+fn terminal_shell() -> Result<String> {
+    let Some(config) = AGENT_CONFIG.get() else {
+        return Err(NodegetError::Other(
+            "Agent config not initialized".to_owned(),
+        ));
+    };
+
+    let configured_shell = config
+        .read()
+        .map_err(|_| NodegetError::Other("AGENT_CONFIG lock poisoned".to_owned()))?
+        .terminal_shell
+        .clone();
+
+    let shell = configured_shell.map_or_else(
+        || default_terminal_shell().to_owned(),
+        |shell| {
+            let shell = shell.trim();
+            if shell.is_empty() {
+                default_terminal_shell().to_owned()
+            } else {
+                shell.to_owned()
+            }
+        },
+    );
+
+    let shell_path = Path::new(&shell);
+    if shell_path.components().count() > 1 && !shell_path.exists() {
+        return Err(NodegetError::InvalidInput(format!(
+            "Configured terminal_shell does not exist: {shell}"
+        )));
+    }
+
+    Ok(shell)
+}
+
+fn default_terminal_shell() -> &'static str {
+    if cfg!(windows) {
+        "cmd.exe"
+    } else if Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "sh"
+    }
 }
 
 // Handle a PTY session.

--- a/docs/guide/config/agent.md
+++ b/docs/guide/config/agent.md
@@ -34,8 +34,8 @@ terminal_shell = "bash"
 # 超出该数量只返回命令的最后结果，上文将被截断，默认 10000
 exec_max_character = 10000
 
-# IP 地址获取服务提供商，可选 ipinfo / Cloudflare，默认 ipinfo
-ip_provider = "ipinfo"
+# IP 地址获取服务提供商，可选 ipinfo / cloudflare，默认 cloudflare
+ip_provider = "cloudflare"
 
 # NTP 服务器地址，用于获取本地时间与 NTP 参考时间的偏差
 # Agent 仅在首次启动时查询该服务器，所有时间戳输出自动应用此偏移

--- a/docs/guide/config/agent.md
+++ b/docs/guide/config/agent.md
@@ -40,8 +40,8 @@ ip_provider = "ipinfo"
 # NTP 服务器地址，用于获取本地时间与 NTP 参考时间的偏差
 # Agent 仅在首次启动时查询该服务器，所有时间戳输出自动应用此偏移
 # 连接失败或超时时自动降级为本地时间（偏移为 0），不影响业务
-# 默认使用阿里云公共 NTP（time.pool.aliyun.com）
-ntp_server = "time.pool.aliyun.com"
+# 默认使用 pool.ntp.org
+ntp_server = "pool.ntp.org"
 
 # 服务器列表
 # 可指定多个，以连接多个 Servers

--- a/docs/guide/config/commandline.md
+++ b/docs/guide/config/commandline.md
@@ -25,8 +25,12 @@ Options:
 
 ```
 ./nodeget-agent -h
-Usage: nodeget-agent --config <CONFIG>
+Usage: nodeget-agent [OPTIONS]
 
 Options:
   -c, --config <CONFIG>
+          [default: config.toml]
+
+  -v, --version
+          [default: false]
 ```

--- a/docs/guide/config/index.md
+++ b/docs/guide/config/index.md
@@ -15,7 +15,7 @@ nodeget-server init -c ./config.toml
 nodeget-server roll-super-token -c ./config.toml
 ```
 
-`-c/--config` 为必填参数；若配置文件无法读取将会 Panic 退出。
+`nodeget-server` 的 `-c/--config` 为必填参数；`nodeget-agent` 未传 `-c/--config` 时默认读取当前工作目录下的 `config.toml`。若配置文件无法读取将会退出。
 
 ## 详细的配置参考
 

--- a/nodeget-lib/src/args_parse/agent.rs
+++ b/nodeget-lib/src/args_parse/agent.rs
@@ -1,3 +1,4 @@
+use crate::config::agent::DEFAULT_AGENT_CONFIG_PATH;
 use palc::Parser;
 
 #[derive(Parser, Debug, Clone)]
@@ -7,7 +8,7 @@ use palc::Parser;
     after_long_help = "This Agent is open-sourced on Github, powered by powerful Rust. Love from NodeGet"
 )]
 pub struct AgentArgs {
-    #[arg(long, short, default_value_t = "config.yaml".to_string())]
+    #[arg(long, short, default_value_t = DEFAULT_AGENT_CONFIG_PATH.to_owned())]
     pub config: String,
 
     #[arg(long, short, default_value_t = false)]

--- a/nodeget-lib/src/config/agent.rs
+++ b/nodeget-lib/src/config/agent.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_DYNAMIC_SUMMARY_REPORT_INTERVAL_MS: u64 = 1000;
 pub const DEFAULT_STATIC_REPORT_INTERVAL_MS: u64 = 300_000;
 pub const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 1000;
 pub const DEFAULT_EXEC_MAX_CHARACTER: usize = 10_000;
-pub const DEFAULT_IP_PROVIDER: IpProvider = IpProvider::IpInfo;
+pub const DEFAULT_IP_PROVIDER: IpProvider = IpProvider::Cloudflare;
 pub const DEFAULT_NTP_SERVER: &str = "pool.ntp.org";
 
 // Agent 配置结构体，定义 Agent 的运行参数

--- a/nodeget-lib/src/config/agent.rs
+++ b/nodeget-lib/src/config/agent.rs
@@ -2,7 +2,12 @@ use crate::config::deserialize_uuid_or_auto;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
+use std::time::Duration;
 use tokio::fs;
+
+pub const DEFAULT_AGENT_CONFIG_PATH: &str = "config.toml";
+pub const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 1000;
+pub const DEFAULT_NTP_SERVER: &str = "pool.ntp.org";
 
 // Agent 配置结构体，定义 Agent 的运行参数
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -90,6 +95,19 @@ pub enum IpProvider {
 }
 
 impl AgentConfig {
+    #[must_use]
+    pub fn connect_timeout_duration(&self) -> Duration {
+        Duration::from_millis(
+            self.connect_timeout_ms
+                .unwrap_or(DEFAULT_CONNECT_TIMEOUT_MS),
+        )
+    }
+
+    #[must_use]
+    pub fn ntp_server_or_default(&self) -> &str {
+        self.ntp_server.as_deref().unwrap_or(DEFAULT_NTP_SERVER)
+    }
+
     /// 从指定路径读取并解析代理配置
     ///
     /// 若配置文件中 `agent_uuid` 为 `"auto_gen"`，则会生成随机 UUIDv4
@@ -155,6 +173,10 @@ impl AgentConfig {
         };
 
         let config: Self = toml::from_str(&config_content)?;
+
+        if matches!(config.connect_timeout_ms, Some(0)) {
+            return Err("connect_timeout_ms must be greater than 0".into());
+        }
 
         // 校验 server name 不能重复
         if let Some(servers) = &config.server {

--- a/nodeget-lib/src/config/agent.rs
+++ b/nodeget-lib/src/config/agent.rs
@@ -6,7 +6,12 @@ use std::time::Duration;
 use tokio::fs;
 
 pub const DEFAULT_AGENT_CONFIG_PATH: &str = "config.toml";
+pub const DEFAULT_DYNAMIC_REPORT_INTERVAL_MS: u64 = 1000;
+pub const DEFAULT_DYNAMIC_SUMMARY_REPORT_INTERVAL_MS: u64 = 1000;
+pub const DEFAULT_STATIC_REPORT_INTERVAL_MS: u64 = 300_000;
 pub const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 1000;
+pub const DEFAULT_EXEC_MAX_CHARACTER: usize = 10_000;
+pub const DEFAULT_IP_PROVIDER: IpProvider = IpProvider::IpInfo;
 pub const DEFAULT_NTP_SERVER: &str = "pool.ntp.org";
 
 // Agent 配置结构体，定义 Agent 的运行参数
@@ -87,20 +92,55 @@ pub struct Server {
 }
 
 // IP 地址获取服务提供商枚举
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum IpProvider {
     IpInfo,
     Cloudflare,
 }
 
+impl Default for IpProvider {
+    fn default() -> Self {
+        DEFAULT_IP_PROVIDER
+    }
+}
+
 impl AgentConfig {
+    #[must_use]
+    pub fn dynamic_report_interval_ms_or_default(&self) -> u64 {
+        self.dynamic_report_interval_ms
+            .unwrap_or(DEFAULT_DYNAMIC_REPORT_INTERVAL_MS)
+    }
+
+    #[must_use]
+    pub fn dynamic_summary_report_interval_ms_or_default(&self) -> u64 {
+        self.dynamic_summary_report_interval_ms
+            .unwrap_or(DEFAULT_DYNAMIC_SUMMARY_REPORT_INTERVAL_MS)
+    }
+
+    #[must_use]
+    pub fn static_report_interval_ms_or_default(&self) -> u64 {
+        self.static_report_interval_ms
+            .unwrap_or(DEFAULT_STATIC_REPORT_INTERVAL_MS)
+    }
+
     #[must_use]
     pub fn connect_timeout_duration(&self) -> Duration {
         Duration::from_millis(
             self.connect_timeout_ms
                 .unwrap_or(DEFAULT_CONNECT_TIMEOUT_MS),
         )
+    }
+
+    #[must_use]
+    pub fn exec_max_character_or_default(&self) -> usize {
+        self.exec_max_character
+            .unwrap_or(DEFAULT_EXEC_MAX_CHARACTER)
+    }
+
+    #[must_use]
+    pub fn ip_provider_or_default(&self) -> IpProvider {
+        self.ip_provider.unwrap_or(DEFAULT_IP_PROVIDER)
     }
 
     #[must_use]
@@ -190,8 +230,8 @@ impl AgentConfig {
 
         // 校验 dynamic_report_interval_ms 必须是 dynamic_summary_report_interval_ms 的整数倍
         {
-            let dynamic_interval = config.dynamic_report_interval_ms.unwrap_or(1000);
-            let summary_interval = config.dynamic_summary_report_interval_ms.unwrap_or(1000);
+            let dynamic_interval = config.dynamic_report_interval_ms_or_default();
+            let summary_interval = config.dynamic_summary_report_interval_ms_or_default();
             if summary_interval == 0 {
                 return Err("dynamic_summary_report_interval_ms must be greater than 0".into());
             }


### PR DESCRIPTION
## 变更说明

修复 Agent 配置文件、示例文档与运行时代码之间的默认值和行为不一致问题。

主要变更：

- 将 `nodeget-agent` 默认配置文件名从 `config.yaml` 改为 `config.toml`，与实际 TOML 解析逻辑保持一致。
- 集中管理 Agent 配置默认值，避免默认值散落在运行时代码中。
- 让 `connect_timeout_ms` 实际作用于 Agent 到 Server 的 WebSocket 建连超时。
- 让 `terminal_shell` 配置实际作用于 WebShell/PTY。
- 统一 NTP 默认值为 `pool.ntp.org`。
- 保持 `ip_provider` 的原程序默认行为为 `cloudflare`，并同步示例和文档。
- 更新命令行配置文档，说明 Agent 未指定 `--config` 时默认读取 `config.toml`。

---

这些更改对目前已经部署的 server or client 应该是没影响的。

但要注意的是：connect_timeout_ms 原来代码里面是硬编码的 5s，现在改成了和文档一致的默认 1s。