### PR TITLE
Fix nodeget-agent JoinSet leak

### DIFF
--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -109,6 +109,14 @@ pub async fn handle_error_message() {
             let mut per_message_tasks = JoinSet::new();
 
             loop {
+                while let Some(join_result) = per_message_tasks.try_join_next() {
+                    if let Err(e) = join_result {
+                        if !e.is_cancelled() {
+                            warn!("[{}] Error handler task failed: {e}", server.name);
+                        }
+                    }
+                }
+
                 let message = match rx.recv().await {
                     Ok(msg) => msg,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {

--- a/agent/src/tasks/mod.rs
+++ b/agent/src/tasks/mod.rs
@@ -202,6 +202,14 @@ pub async fn handle_task() {
             // 切换至 Arc 带来的 cache-line 争用，权衡后维持 clone。
 
             loop {
+                while let Some(join_result) = per_task.try_join_next() {
+                    if let Err(e) = join_result {
+                        if !e.is_cancelled() {
+                            warn!("[{}] Per-message task failed: {e}", server.name);
+                        }
+                    }
+                }
+
                 let message = match rx.recv().await {
                     Ok(msg) => msg,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {


### PR DESCRIPTION
This stops the agent-side RSS growth caused by unbounded completed JoinSet entries in:\n\n- agent/src/tasks/mod.rs\n- agent/src/rpc/mod.rs\n\nEach loop now drains ready JoinSet completions with try_join_next() before waiting for the next broadcast message, so finished per-message handlers are removed from the set instead of accumulating forever.\n\nNotes:\n- no protocol changes\n- fork main was fast-forwarded to upstream main before this branch\n- I could not run cargo locally because the Rust toolchain is not installed in this environment