### PR TITLE
Fix: Drain completed JoinSet tasks in agent loops

### DIFF
--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -109,6 +109,14 @@ pub async fn handle_error_message() {
             let mut per_message_tasks = JoinSet::new();
 
             loop {
+                while let Some(join_result) = per_message_tasks.try_join_next() {
+                    if let Err(e) = join_result {
+                        if !e.is_cancelled() {
+                            warn!("[{}] Error handler task failed: {e}", server.name);
+                        }
+                    }
+                }
+
                 let message = match rx.recv().await {
                     Ok(msg) => msg,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {

--- a/agent/src/tasks/mod.rs
+++ b/agent/src/tasks/mod.rs
@@ -202,6 +202,14 @@ pub async fn handle_task() {
             // 切换至 Arc 带来的 cache-line 争用，权衡后维持 clone。
 
             loop {
+                while let Some(join_result) = per_task.try_join_next() {
+                    if let Err(e) = join_result {
+                        if !e.is_cancelled() {
+                            warn!("[{}] Per-message task failed: {e}", server.name);
+                        }
+                    }
+                }
+
                 let message = match rx.recv().await {
                     Ok(msg) => msg,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {


### PR DESCRIPTION
This fixes agent-side RSS growth by draining completed JoinSet entries in the per-server and error-message loops before waiting for the next broadcast message.

Verification:
- Docker build from ./agent on linux/amd64: passed
- rustfmt check on agent/src/rpc/mod.rs and agent/src/tasks/mod.rs: passed

Notes:
- I fast-forwarded Microdent/NodeGet main to the latest upstream main before pushing this branch.
- I kept the change scoped to the two agent loops that were accumulating completed JoinSet tasks.